### PR TITLE
Make splitting optional

### DIFF
--- a/plugin/godef.vim
+++ b/plugin/godef.vim
@@ -4,6 +4,10 @@ if !exists("g:godef_command")
     let g:godef_command = "godef"
 endif
 
+if !exists("g:godef_split")
+    let g:godef_split = 1
+endif
+
 function! GodefUnderCursor()
     let offs=line2byte(line('.'))+col('.')-1
     call Godef("-o=" . offs)
@@ -15,7 +19,9 @@ function! Godef(arg)
         let out=substitute(out, '\n$', '', '')
         echom out
     else
-        split
+        if g:godef_split
+            split
+	endif
         lexpr out
     end
 endfunction


### PR DESCRIPTION
Setting g:godef_split=0 will disable splitting

Signed-off-by: Saggi Mizrahi ficoos@gmail.com
