### PR TITLE
Multibyte

### DIFF
--- a/plugin/godef.vim
+++ b/plugin/godef.vim
@@ -34,7 +34,7 @@ function! Godef(arg)
         let filename=bufname("%")
     endif
 
-    let out=system(g:godef_command . " -f=" . filename . " " . a:arg)
+    let out=system(g:godef_command . " -f=" . shellescape(filename) . " " . shellescape(a:arg))
 
     if out =~ 'godef: '
         let out=substitute(out, '\n$', '', '')


### PR DESCRIPTION
line2byte depend on &encoding. For example, &fileencoding is not same as &encoding, it doesn't work correctly.
