### PR TITLE
Small fixes

### DIFF
--- a/plugin/godef.vim
+++ b/plugin/godef.vim
@@ -28,31 +28,26 @@ endfunction
 
 function! Godef(arg)
 
-    if &modified
-        " XXX not ideal, but I couldn't find a good way
-        "     to create a temporary buffer for use with
-        "     a filter
-        let filename=tempname()
-        echomsg filename
-        execute ":write " . filename
-    else
-        let filename=bufname("%")
-    endif
+    let tempfile=tempname()
+    echomsg tempfile
+    call writefile(getbufline(bufnr('%'), 1, '$'), tempfile)
 
-    let out=system(g:godef_command . " -f=" . shellescape(filename) . " " . shellescape(a:arg))
+    let out=system(g:godef_command . " -f=" . shellescape(tempfile) . " " . shellescape(a:arg))
+
+    call delete(tempfile)
 
     if out =~ 'godef: '
         let out=substitute(out, '\n$', '', '')
         echom out
-    elseif g:godef_same_file_in_same_window == 1 && (out) =~ expand('%:t')
+    elseif g:godef_same_file_in_same_window == 1 && (out) =~ "^".tempfile
+        let x=stridx(out, ":")
+        let out=expand("%:t").strpart(out, x, len(out)-x)
         lexpr out
     else
-        if out !~ '^'.bufname("%")
-          if g:godef_split == 1
-              split
-          elseif g:godef_split == 2
-              tabnew
-          endif
+        if g:godef_split == 1
+            split
+        elseif g:godef_split == 2
+            tabnew
         endif
         lexpr out
     end


### PR DESCRIPTION
Fixes:
- Off by two error when encoding is utf8
- Makes call to `Godef(...)` silent when called from under cursor (saves having to hit enter to acknowledge)
- Always use a `tempname()` file (this is relatively [standard practice](https://github.com/majutsushi/tagbar/blob/master/autoload/tagbar.vim#L2000-L2003))
- Delete the `tempfile` once created
- Use `writefile` to avoid triggering any events (e.g. [`vim-gocode`](https://github.com/Blackrush/vim-gocode) reformats on a `:w`

Thanks
