### PR TITLE
Fix same file in same window option.

### DIFF
--- a/plugin/godef.vim
+++ b/plugin/godef.vim
@@ -27,7 +27,6 @@ function! GodefUnderCursor()
 endfunction
 
 function! Godef(arg)
-
     let tempfile=tempname()
     echomsg tempfile
     call writefile(getbufline(bufnr('%'), 1, '$'), tempfile)
@@ -39,16 +38,20 @@ function! Godef(arg)
     if out =~ 'godef: '
         let out=substitute(out, '\n$', '', '')
         echom out
-    elseif g:godef_same_file_in_same_window == 1 && (out) =~ "^".tempfile
-        let x=stridx(out, ":")
-        let out=expand("%").strpart(out, x, len(out)-x)
-        lexpr out
     else
-        if g:godef_split == 1
-            split
-        elseif g:godef_split == 2
-            tabnew
+        if (out) =~ "^".tempfile
+            let x=stridx(out, ":")
+            let out=expand("%").strpart(out, x, len(out)-x)
         endif
+
+        if g:godef_same_file_in_same_window == 0
+            if g:godef_split == 1
+                split
+            elseif g:godef_split == 2
+                tabnew
+            endif
+        endif
+
         lexpr out
     end
 endfunction


### PR DESCRIPTION
Honor the `g:godef_same_file_in_same_window` option without breaking
default behavior.

With default `g:godef_same_file_in_same_window`, the jump will fail
since the temp file is deleted. It is still broken if temp file exists,
because Vim will jump to the temporary file, other than current file.
